### PR TITLE
fix ui player search test

### DIFF
--- a/app/src/androidTest/java/com/goblin/qrhunter/ui/MainActivityTest.java
+++ b/app/src/androidTest/java/com/goblin/qrhunter/ui/MainActivityTest.java
@@ -13,7 +13,11 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.ActivityTestRule;
 
 import com.goblin.qrhunter.MainActivity;
+import com.goblin.qrhunter.Player;
 import com.goblin.qrhunter.R;
+import com.goblin.qrhunter.data.PlayerRepository;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.robotium.solo.Solo;
 
 import org.junit.After;
@@ -23,12 +27,21 @@ import org.junit.Test;
 
 public class MainActivityTest {
     private Solo solo;
+    private String username_test_value = "user49394473";
     @Rule
     public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, true, true);
 
     @Before
     public void setUp() throws Exception{
         solo = new Solo(InstrumentationRegistry.getInstrumentation(),rule.getActivity());
+        PlayerRepository playerRepository = new PlayerRepository();
+        Task< Player> getplayer = playerRepository.getPlayerByUsername(username_test_value);
+        Tasks.await(getplayer);
+        if(getplayer.getResult() == null) {
+            Player p1 = new Player();
+            p1.setUsername(username_test_value);
+            playerRepository.add(p1);
+        }
     }
     // Gets the (main) activity
     public void start() throws Exception{
@@ -101,7 +114,7 @@ public class MainActivityTest {
         solo.sendKey(KeyEvent.KEYCODE_3);
         solo.sendKey(KeyEvent.KEYCODE_9);
         solo.sendKey(KeyEvent.KEYCODE_ENTER);
-        assertTrue(solo.waitForText("user49394473"));
+        assertTrue(solo.waitForText(username_test_value));
         solo.sleep(2000);
         solo.clickOnView(solo.getView(R.id.searched_username));
         solo.sleep(1000);


### PR DESCRIPTION
The player search test searches for a specific user, which breaks when using a firebase emulator. Add player if doesn't already exist in the emulator/remote.